### PR TITLE
Fix html tag hydration mismatch

### DIFF
--- a/solon-investment-society/src/app/layout.tsx
+++ b/solon-investment-society/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         <div className="min-h-screen flex flex-col">
           <header className="sticky top-0 z-50 border-b border-border/60 bg-white/70 dark:bg-background/60 backdrop-blur">


### PR DESCRIPTION
Add `suppressHydrationWarning` to the `<html>` element to resolve hydration mismatch warnings caused by browser extensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9a2164c-075e-4959-973f-7101130483b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9a2164c-075e-4959-973f-7101130483b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

