### PR TITLE
Fix and re-add page transitions

### DIFF
--- a/solon-investment-society/src/app/layout.tsx
+++ b/solon-investment-society/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
 import Image from "next/image";
 import "./globals.css";
+import PageTransition from "./components/PageTransition";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -53,7 +54,9 @@ export default function RootLayout({
           </header>
           <main className="relative flex-1">
             <div aria-hidden className="pointer-events-none absolute inset-x-0 -top-32 -z-10 h-[450px] bg-gradient-to-b from-accent/15 to-transparent"></div>
-            {children}
+            <PageTransition>
+              {children}
+            </PageTransition>
           </main>
           <footer className="border-t border-border/60">
             <div className="max-w-7xl mx-auto px-6 py-8 text-sm text-muted-foreground">

--- a/solon-investment-society/src/app/template.tsx
+++ b/solon-investment-society/src/app/template.tsx
@@ -10,10 +10,10 @@ function MotionWrapper({ children }: PropsWithChildren) {
   const isPresent = useIsPresent();
   return (
     <motion.div
-      initial={{ opacity: 0, x: -8 }}
-      animate={{ opacity: 1, x: 0, transition: { duration: 0.36, ease: [0.22, 1, 0.36, 1] } }}
-      exit={{ opacity: 0, y: 8, transition: { duration: 0.28, ease: [0.22, 1, 0.36, 1] } }}
-      style={{ position: isPresent ? "relative" : "absolute", inset: 0 }}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0, transition: { duration: 0.32, ease: [0.22, 1, 0.36, 1] } }}
+      exit={{ opacity: 0, y: -8, transition: { duration: 0.26, ease: [0.22, 1, 0.36, 1] } }}
+      style={{ position: isPresent ? "relative" : "absolute", inset: 0, width: "100%" }}
     >
       {children}
     </motion.div>


### PR DESCRIPTION
Re-add subtle page transitions by wrapping page content with `PageTransition` in `layout.tsx` and refining the animation properties in `template.tsx`.

The previous page transitions were not working, and this change re-enables them with a tasteful crossfade/slide effect, ensuring the navigation bar remains static during page changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc1c8c2b-9962-4f3d-86c1-302486a8eda5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc1c8c2b-9962-4f3d-86c1-302486a8eda5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

